### PR TITLE
Remove liberl_interface from port compiler on Windows

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -721,7 +721,7 @@ default_env() ->
       "$LINKER $PORT_IN_FILES $LDFLAGS $EXE_LDFLAGS /OUT:$PORT_OUT_FILE"},
      %% ERL_CFLAGS are ok as -I even though strictly it should be /I
      {"win32", "ERL_LDFLAGS",
-      " /LIBPATH:$ERL_EI_LIBDIR erl_interface.lib ei.lib"},
+      " /LIBPATH:$ERL_EI_LIBDIR ei.lib"},
      {"win32", "DRV_CFLAGS", "/Zi /Wall $ERL_CFLAGS"},
      {"win32", "DRV_LDFLAGS", "/DLL $ERL_LDFLAGS"}
     ].


### PR DESCRIPTION
We arleady removed it for unix-y systems, so we are just trying to
match the behavior for Windows.