### PR TITLE
Relax xref ANNO limitation

### DIFF
--- a/src/rebar_xref.erl
+++ b/src/rebar_xref.erl
@@ -288,7 +288,7 @@ find_function_source(M, F, A, Bin) ->
     AbstractCode = beam_lib:chunks(Bin, [abstract_code]),
     {ok, {M, [{abstract_code, {raw_abstract_v1, Code}}]}} = AbstractCode,
     %% Extract the original source filename from the abstract code
-    [{attribute, 1, file, {Source, _}} | _] = Code,
+    [{attribute, _, file, {Source, _}} | _] = Code,
     %% Extract the line number for a given function def
     Fn = [E || E <- Code,
                safe_element(1, E) == function,


### PR DESCRIPTION
Currently this xref interface assumes an ANNO format of a single line number, but versions of OTP > 23 return a tuple, resulting in a an error like:
```
ERROR: xref failed while processing /Users/jay/repos/couchdb/src/snappy: {'EXIT',
 {{badmatch,
   [{attribute,{1,1},file,{"src/snappy.erl",1}},
```
This relaxes the assumption on any particular ANNO format and accepts them all.