### PR TITLE
Relax ANNO limitation in test coverage utils

### DIFF
--- a/src/rebar_cover_utils.erl
+++ b/src/rebar_cover_utils.erl
@@ -184,7 +184,7 @@ has_header(Mod, Header) ->
            end,
     {ok, {_, [{abstract_code, {_, AC}}]}} =
         beam_lib:chunks(Mod1, [abstract_code]),
-    [F || {attribute, 1, file, {F, 1}} <- AC,
+    [F || {attribute, _, file, {F, 1}} <- AC,
           string:str(F, Header) =/= 0] =/= [].
 
 align_notcovered_count(Module, Covered, NotCovered, false) ->


### PR DESCRIPTION
Currently the code to determine whether a particular file attribute ("header") exists assumes an ANNO format of a single line number, but versions of OTP > 23 return a tuple, so that pattern will never match, resulting in coverage failing to account for the inclusion of the `eunit.hrl` file, and then incorrectly calculating the coverage of the test module as 66%, rather than the expected 100%.

This change relaxes the pattern so that it will also match tuples, and fixes the eunit coverage test.

```
make test_eunit
```
should now pass on OTP version >= 23.

See also: https://github.com/apache/couchdb-rebar/pull/5