### PR TITLE
Add missing Windows templates

### DIFF
--- a/src/rebar_port_compiler.erl
+++ b/src/rebar_port_compiler.erl
@@ -621,8 +621,9 @@ target_type1(".dll") -> drv;
 target_type1("")     -> exe;
 target_type1(".exe") -> exe.
 
+
 erl_interface_dir(Subdir) ->
-    case code:lib_dir(erl_interface, Subdir) of
+    case filename:join(code:lib_dir(erl_interface), Subdir) of
         {error, bad_name} ->
             throw({error, {erl_interface,Subdir,"code:lib_dir(erl_interface)"
                            "is unable to find the erl_interface library."}});
@@ -630,6 +631,12 @@ erl_interface_dir(Subdir) ->
     end.
 
 default_env() ->
+    ErlInterfaceIncludeDir = erl_interface_dir(include),
+    ErlInterfaceHeader = filename:join(ErlInterfaceIncludeDir, "erl_interface.h"),
+    ErlInterfaceLibs = case filelib:is_file(ErlInterfaceHeader) of
+                           true -> ["erl_interface", "ei"];
+                           false -> ["ei"]
+                       end,
     Arch = os:getenv("REBAR_TARGET_ARCH"),
     Vsn = os:getenv("REBAR_TARGET_ARCH_VSN"),
     [
@@ -650,9 +657,9 @@ default_env() ->
      {"DRV_CC_TEMPLATE",
       "$CC -c $CFLAGS $DRV_CFLAGS $PORT_IN_FILES -o $PORT_OUT_FILE"},
      {"DRV_LINK_TEMPLATE",
-      "$CC $PORT_IN_FILES $LDFLAGS $DRV_LDFLAGS -o $PORT_OUT_FILE"},
+      "$CC $PORT_IN_FILES $LDFLAGS $LDLIBS $DRV_LDFLAGS -o $PORT_OUT_FILE"},
      {"DRV_LINK_CXX_TEMPLATE",
-      "$CXX $PORT_IN_FILES $LDFLAGS $DRV_LDFLAGS -o $PORT_OUT_FILE"},
+      "$CXX $PORT_IN_FILES $LDFLAGS $LDLIBS $DRV_LDFLAGS -o $PORT_OUT_FILE"},
      {"EXE_CXX_TEMPLATE",
       "$CXX -c $CXXFLAGS $EXE_CFLAGS $PORT_IN_FILES -o $PORT_OUT_FILE"},
      {"EXE_CC_TEMPLATE",
@@ -668,12 +675,13 @@ default_env() ->
 
      {"ERL_CFLAGS", lists:concat(
                       [
-                       " -I\"", erl_interface_dir(include),
+                       " -I\"", ErlInterfaceIncludeDir,
                        "\" -I\"", filename:join(erts_dir(), "include"),
                        "\" "
                       ])},
      {"ERL_EI_LIBDIR", lists:concat(["\"", erl_interface_dir(lib), "\""])},
-     {"ERL_LDFLAGS"  , " -L$ERL_EI_LIBDIR -lei"},
+     {"ERL_LDFLAGS"  , lists:concat([" -L$ERL_EI_LIBDIR"] ++
+                                    [" -l"++EiLib || EiLib <- ErlInterfaceLibs])},
      {"ERLANG_ARCH"  , rebar_utils:wordsize()},
      {"ERLANG_TARGET", rebar_utils:get_arch()},
 
@@ -712,6 +720,8 @@ default_env() ->
       "$CC /c $CFLAGS $DRV_CFLAGS $PORT_IN_FILES /Fo$PORT_OUT_FILE"},
      {"win32", "DRV_LINK_TEMPLATE",
       "$LINKER $PORT_IN_FILES $LDFLAGS $DRV_LDFLAGS /OUT:$PORT_OUT_FILE"},
+     {"win32", "DRV_LINK_CXX_TEMPLATE",
+      "$LINKER $PORT_IN_FILES $LDFLAGS $DRV_LDFLAGS /OUT:$PORT_OUT_FILE"},
      %% DRV_* and EXE_* Templates are identical
      {"win32", "EXE_CXX_TEMPLATE",
       "$CXX /c $CXXFLAGS $EXE_CFLAGS $PORT_IN_FILES /Fo$PORT_OUT_FILE"},
@@ -719,9 +729,12 @@ default_env() ->
       "$CC /c $CFLAGS $EXE_CFLAGS $PORT_IN_FILES /Fo$PORT_OUT_FILE"},
      {"win32", "EXE_LINK_TEMPLATE",
       "$LINKER $PORT_IN_FILES $LDFLAGS $EXE_LDFLAGS /OUT:$PORT_OUT_FILE"},
+     {"win32", "EXE_LINK_CXX_TEMPLATE",
+      "$LINKER $PORT_IN_FILES $LDFLAGS $EXE_LDFLAGS /OUT:$PORT_OUT_FILE"},
      %% ERL_CFLAGS are ok as -I even though strictly it should be /I
      {"win32", "ERL_LDFLAGS",
-      " /LIBPATH:$ERL_EI_LIBDIR ei.lib"},
+      lists:concat([" /LIBPATH:$ERL_EI_LIBDIR "] ++
+                    [EiLib++".lib " || EiLib <- ErlInterfaceLibs])},
      {"win32", "DRV_CFLAGS", "/Zi /Wall $ERL_CFLAGS"},
      {"win32", "DRV_LDFLAGS", "/DLL $ERL_LDFLAGS"}
     ].


### PR DESCRIPTION
Compiling jiffy on Windows doesn't work because
of two missing templates for the default environment.

Ported these settings from the rebar3 port compiler [1].

[1] https://github.com/blt/port_compiler/blob/935c20744b6f0adf8e6ea92e3da939aae2064b0f/src/pc_port_env.erl