### PR TITLE
Replace deprecated functions for OTP 27

### DIFF
--- a/src/rebar_ct.erl
+++ b/src/rebar_ct.erl
@@ -288,7 +288,7 @@ search_ct_specs_from(Cwd, TestDir, Config) ->
 build_name(Config) ->
     %% generate a unique name for our test node, we want
     %% to make sure the odds of name clashing are low
-    Random = integer_to_list(crypto:rand_uniform(0, 10000)),
+    Random = integer_to_list(rand:uniform(10000)),
     case rebar_config:get_local(Config, ct_use_short_names, false) of
         true -> "-sname test" ++ Random;
         false -> " -name test" ++ Random ++ "@" ++ net_adm:localhost()

--- a/src/rebar_dialyzer.erl
+++ b/src/rebar_dialyzer.erl
@@ -238,9 +238,9 @@ deps_apps(Config) ->
     [element(1, Dep) || Dep <- rebar_config:get_local(Config, deps, [])].
 
 app_lib_dir(App) ->
-    case code:lib_dir(App, ebin) of
+    case code:lib_dir(App) of
         {error, _}=Err ->
             ?ABORT("Failed to get ebin dir for app: ~p~n~p~n", [App, Err]);
         Dir ->
-            Dir
+            filename:join(Dir, "ebin")
     end.

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -267,12 +267,13 @@ define_if(_Def, false) -> [].
 is_lib_avail(Config, DictKey, Mod, Hrl, Name) ->
     case rebar_config:get_xconf(Config, DictKey, undefined) of
         undefined ->
-            IsAvail = case code:lib_dir(Mod, include) of
-                          {error, bad_name} ->
-                              false;
-                          Dir ->
-                              filelib:is_regular(filename:join(Dir, Hrl))
-                      end,
+            IsAvail =
+                case code:lib_dir(Mod) of
+                    {error, bad_name} ->
+                        false;
+                    Dir ->
+                        filelib:is_regular(filename:join([Dir, "include", Hrl]))
+                end,
             NewConfig = rebar_config:set_xconf(Config, DictKey, IsAvail),
             ?DEBUG("~s availability: ~p\n", [Name, IsAvail]),
             {NewConfig, IsAvail};
@@ -705,9 +706,9 @@ expand_include_lib_path(File) ->
                  _ ->
                      filename:join(Parts)
              end,
-    case code:lib_dir(list_to_atom(Lib), list_to_atom(SubDir)) of
+    case code:lib_dir(list_to_atom(Lib)) of
         {error, bad_name} -> [];
-        Dir -> [filename:join(Dir, File1)]
+        Dir -> [filename:join([Dir, SubDir, File1])]
     end.
 
 %%

--- a/src/rebar_escripter.erl
+++ b/src/rebar_escripter.erl
@@ -138,13 +138,14 @@ info_help(Description) ->
 get_app_beams([], Acc) ->
     Acc;
 get_app_beams([App | Rest], Acc) ->
-    case code:lib_dir(App, ebin) of
+    case code:lib_dir(App) of
         {error, bad_name} ->
             ?ABORT("Failed to get ebin/ directory for "
                    "~p escript_incl_apps.", [App]);
-        Path ->
+        PathApp ->
+            PathEbin = filename:join(PathApp, "ebin"),
             Prefix = filename:join(atom_to_list(App), "ebin"),
-            Acc2 = load_files(Prefix, "*", Path),
+            Acc2 = load_files(Prefix, "*", PathEbin),
             get_app_beams(Rest, Acc2 ++ Acc)
     end.
 

--- a/src/rebar_eunit.erl
+++ b/src/rebar_eunit.erl
@@ -279,7 +279,7 @@ randomize_suites(Config, Modules) ->
         undefined ->
             Modules;
         "true" ->
-            Seed = crypto:rand_uniform(1, 65535),
+            Seed = rand:uniform(65535),
             randomize_suites1(Modules, Seed);
         String ->
             try list_to_integer(String) of


### PR DESCRIPTION
- Replace `crypto:rand_uniform/2` with `rand:uniform/1`.
- Replace `code:lib_dir(App, SubDir)` with `filename:join(code:lib_dir(App), SubDir)`.